### PR TITLE
Spheroidal grain resources

### DIFF
--- a/SKIRT/core/SpheroidalGraphiteGrainComposition.cpp
+++ b/SKIRT/core/SpheroidalGraphiteGrainComposition.cpp
@@ -18,10 +18,29 @@ bool SpheroidalGraphiteGrainComposition::resourcesForSpheroidalEmission(bool& re
                                                                         std::string& tableName1,
                                                                         std::string& tableName2) const
 {
-    resource = false;
-    interpol = 0.;
-    tableName1 = _spheroidalEmissionTable;
-    tableName2 = string();
+
+    switch (_tableType)
+    {
+        case TableType::Builtin:
+            resource = true;
+            interpol = 0;
+            tableName1 = "SpheroidalGraphiteNonAlignedEmissionOpticalProps";
+            tableName2 = string();
+            break;
+        case TableType::OneTable:
+            resource = false;
+            interpol = 0;
+            tableName1 = _emissionTable;
+            tableName2 = string();
+            break;
+        case TableType::TwoTables:
+            resource = false;
+            interpol = _alignmentFraction;
+            tableName1 = _nonAlignedEmissionTable;
+            tableName2 = _alignedEmissionTable;
+            break;
+    }
+
     return true;
 }
 

--- a/SKIRT/core/SpheroidalGraphiteGrainComposition.hpp
+++ b/SKIRT/core/SpheroidalGraphiteGrainComposition.hpp
@@ -17,18 +17,63 @@
 
     The optical scattering and absorption properties and the calorimetric properties are taken from
     the PolarizedGraphiteGrainComposition class, from which this class derives. The optical
-    properties driving the polarization signature for therrmal emission are obtained from
+    properties driving the polarization signature for thermal emission are obtained from
     additional built-in tables or can be provided by the user, as described below.
-
-    TO DO: describe built-in and file input options. */
+    
+    In the current implementation, the internally used optical properties table always assumes a
+    fixed spheroidal dust model with a constant alignment. The table generally is a linear
+    combination of a table for non-aligned grains and one for aligned grains, combined using a
+    linear alignment fraction between 0 and 1. Contrary to the SpheroidalSilicateGrainComposition
+    case, the builtin version assumes that graphite grains are non-aligned, and hence consists of
+    a single table without an alignment fraction. This builtin table is simply a copy of the
+    DraineGraphiteOpticalProps table that contains the additional columns required to handle the
+    angular dependence of the optical properties (which is constant in the non-aligned case).
+    
+    If this default model is not sufficient, users can provide their own custom tables, e.g.
+    generated using CosTuuM. There are two options: either the user computes the tables for a
+    specific alignment fraction and provides a single table, or the user provides separate tables
+    for perfectly aligned and non-aligned grains. In the latter case, SKIRT will use the alignment
+    fraction to appropriately interpolate between the two tables, as in the builtin case.
+    
+    The choice between the 3 different scenarios (builtin table without interpolation, a single
+    custom table without interpolation or two custom tables with interpolation) is configured
+    through an enum. */
 class SpheroidalGraphiteGrainComposition : public PolarizedGraphiteGrainComposition
 {
+
+    ENUM_DEF(TableType, Builtin, OneTable, TwoTables)
+        ENUM_VAL(TableType, Builtin, "builtin resources")
+        ENUM_VAL(TableType, OneTable, "single custom table")
+        ENUM_VAL(TableType, TwoTables, "two custom tables with interpolation")
+    ENUM_END()
+
     ITEM_CONCRETE(SpheroidalGraphiteGrainComposition, PolarizedGraphiteGrainComposition,
                   "a spheroidal graphite dust grain composition with support for polarization")
         ATTRIBUTE_TYPE_DISPLAYED_IF(SpheroidalSilicateGrainComposition, "Spheroidal")
 
-        PROPERTY_STRING(spheroidalEmissionTable,
-                        "the name of the file tabulating properties for polarized emission by spheroidal grains")
+        PROPERTY_ENUM(tableType, TableType, "the type of emission tables to use")
+        ATTRIBUTE_DEFAULT_VALUE(tableType, "Builtin")
+
+        PROPERTY_STRING(emissionTable, "the name of the file tabulating properties for polarized emission by "
+                                       "arbitrarily aligned spheroidal grains")
+        ATTRIBUTE_RELEVANT_IF(emissionTable, "tableTypeOneTable")
+
+        PROPERTY_STRING(
+            alignedEmissionTable,
+            "the name of the file tabulating properties for polarized emission by perfectly aligned spheroidal grains")
+        ATTRIBUTE_RELEVANT_IF(alignedEmissionTable, "tableTypeTwoTables")
+
+        PROPERTY_STRING(
+            nonAlignedEmissionTable,
+            "the name of the file tabulating properties for polarized emission by non-aligned spheroidal grains")
+        ATTRIBUTE_RELEVANT_IF(nonAlignedEmissionTable, "tableTypeTwoTables")
+
+        PROPERTY_DOUBLE(alignmentFraction,
+                        "the alignment fraction of the spheroidal grains with the local magnetic field")
+        ATTRIBUTE_DEFAULT_VALUE(alignmentFraction, "1.")
+        ATTRIBUTE_MIN_VALUE(alignmentFraction, "0.")
+        ATTRIBUTE_MAX_VALUE(alignmentFraction, "1.")
+        ATTRIBUTE_RELEVANT_IF(alignmentFraction, "tableTypeTwoTables")
 
     ITEM_END()
 

--- a/SKIRT/core/SpheroidalSilicateGrainComposition.cpp
+++ b/SKIRT/core/SpheroidalSilicateGrainComposition.cpp
@@ -4,6 +4,21 @@
 ///////////////////////////////////////////////////////////////// */
 
 #include "SpheroidalSilicateGrainComposition.hpp"
+#include "FatalError.hpp"
+
+////////////////////////////////////////////////////////////////////
+
+void SpheroidalSilicateGrainComposition::setupSelfBefore()
+{
+
+    PolarizedSilicateGrainComposition::setupSelfBefore();
+
+    if (!_alignedEmissionTable.empty() && _alignmentFraction != 1. && _nonAlignedEmissionTable.empty())
+    {
+        throw FATALERROR(
+            "No custom emission table provided for non-aligned grains, yet the alignment fraction is not 1!");
+    }
+}
 
 ////////////////////////////////////////////////////////////////////
 
@@ -18,10 +33,32 @@ bool SpheroidalSilicateGrainComposition::resourcesForSpheroidalEmission(bool& re
                                                                         std::string& tableName1,
                                                                         std::string& tableName2) const
 {
-    resource = false;
-    interpol = 0.;
-    tableName1 = _spheroidalEmissionTable;
-    tableName2 = string();
+
+    if (!_alignedEmissionTable.empty())
+    {
+        resource = false;
+        if (!_nonAlignedEmissionTable.empty())
+        {
+            interpol = _alignmentFraction;
+            tableName1 = _nonAlignedEmissionTable;
+            tableName2 = _alignedEmissionTable;
+        }
+        else
+        {
+            interpol = 0;
+            tableName1 = _alignedEmissionTable;
+            tableName2 = string();
+        }
+    }
+    else
+    {
+        throw FATALERROR("Spheroidal tables are not part of the SKIRT resources yet!");
+        resource = true;
+        interpol = _alignmentFraction;
+        tableName1 = "NAME OF PRECOMPUTED NON-ALIGNED TABLE";
+        tableName2 = "NAME OF PRECOMPUTED ALIGNED TABLE";
+    }
+
     return true;
 }
 

--- a/SKIRT/core/SpheroidalSilicateGrainComposition.cpp
+++ b/SKIRT/core/SpheroidalSilicateGrainComposition.cpp
@@ -8,20 +8,6 @@
 
 ////////////////////////////////////////////////////////////////////
 
-void SpheroidalSilicateGrainComposition::setupSelfBefore()
-{
-
-    PolarizedSilicateGrainComposition::setupSelfBefore();
-
-    if (!_alignedEmissionTable.empty() && _alignmentFraction != 1. && _nonAlignedEmissionTable.empty())
-    {
-        throw FATALERROR(
-            "No custom emission table provided for non-aligned grains, yet the alignment fraction is not 1!");
-    }
-}
-
-////////////////////////////////////////////////////////////////////
-
 string SpheroidalSilicateGrainComposition::name() const
 {
     return "Spheroidal_Polarized_Draine_Silicate";
@@ -34,29 +20,27 @@ bool SpheroidalSilicateGrainComposition::resourcesForSpheroidalEmission(bool& re
                                                                         std::string& tableName2) const
 {
 
-    if (!_alignedEmissionTable.empty())
-    {
-        resource = false;
-        if (!_nonAlignedEmissionTable.empty())
-        {
-            interpol = _alignmentFraction;
-            tableName1 = _nonAlignedEmissionTable;
-            tableName2 = _alignedEmissionTable;
-        }
-        else
-        {
-            interpol = 0;
-            tableName1 = _alignedEmissionTable;
-            tableName2 = string();
-        }
-    }
-    else
+    if (_tableType == TableType::Builtin)
     {
         throw FATALERROR("Spheroidal tables are not part of the SKIRT resources yet!");
         resource = true;
         interpol = _alignmentFraction;
         tableName1 = "NAME OF PRECOMPUTED NON-ALIGNED TABLE";
         tableName2 = "NAME OF PRECOMPUTED ALIGNED TABLE";
+    }
+    else if (_tableType == TableType::OneTable)
+    {
+        resource = false;
+        interpol = 0;
+        tableName1 = _emissionTable;
+        tableName2 = string();
+    }
+    else if (_tableType == TableType::TwoTables)
+    {
+        resource = false;
+        interpol = _alignmentFraction;
+        tableName1 = _nonAlignedEmissionTable;
+        tableName2 = _alignedEmissionTable;
     }
 
     return true;

--- a/SKIRT/core/SpheroidalSilicateGrainComposition.cpp
+++ b/SKIRT/core/SpheroidalSilicateGrainComposition.cpp
@@ -20,27 +20,26 @@ bool SpheroidalSilicateGrainComposition::resourcesForSpheroidalEmission(bool& re
                                                                         std::string& tableName2) const
 {
 
-    if (_tableType == TableType::Builtin)
+    switch (_tableType)
     {
-        throw FATALERROR("Spheroidal tables are not part of the SKIRT resources yet!");
-        resource = true;
-        interpol = _alignmentFraction;
-        tableName1 = "NAME OF PRECOMPUTED NON-ALIGNED TABLE";
-        tableName2 = "NAME OF PRECOMPUTED ALIGNED TABLE";
-    }
-    else if (_tableType == TableType::OneTable)
-    {
-        resource = false;
-        interpol = 0;
-        tableName1 = _emissionTable;
-        tableName2 = string();
-    }
-    else if (_tableType == TableType::TwoTables)
-    {
-        resource = false;
-        interpol = _alignmentFraction;
-        tableName1 = _nonAlignedEmissionTable;
-        tableName2 = _alignedEmissionTable;
+        case TableType::Builtin:
+            resource = true;
+            interpol = _alignmentFraction;
+            tableName1 = "SpheroidalSilicateNonAlignedEmissionOpticalProps";
+            tableName2 = "SpheroidalSilicateAlignedEmissionOpticalProps";
+            break;
+        case TableType::OneTable:
+            resource = false;
+            interpol = 0;
+            tableName1 = _emissionTable;
+            tableName2 = string();
+            break;
+        case TableType::TwoTables:
+            resource = false;
+            interpol = _alignmentFraction;
+            tableName1 = _nonAlignedEmissionTable;
+            tableName2 = _alignedEmissionTable;
+            break;
     }
 
     return true;

--- a/SKIRT/core/SpheroidalSilicateGrainComposition.hpp
+++ b/SKIRT/core/SpheroidalSilicateGrainComposition.hpp
@@ -23,34 +23,44 @@
     TO DO: describe built-in and file input options. */
 class SpheroidalSilicateGrainComposition : public PolarizedSilicateGrainComposition
 {
+
+    ENUM_DEF(TableType, Builtin, OneTable, TwoTables)
+        ENUM_VAL(TableType, Builtin, "builtin resources")
+        ENUM_VAL(TableType, OneTable, "single custom table")
+        ENUM_VAL(TableType, TwoTables, "two custom tables with interpolation")
+    ENUM_END()
+
     ITEM_CONCRETE(SpheroidalSilicateGrainComposition, PolarizedSilicateGrainComposition,
                   "a spheroidal silicate dust grain composition with support for polarization")
         ATTRIBUTE_TYPE_DISPLAYED_IF(SpheroidalSilicateGrainComposition, "Spheroidal")
 
+        PROPERTY_ENUM(tableType, TableType, "the type of emission tables to use")
+        ATTRIBUTE_DEFAULT_VALUE(tableType, "Builtin")
+
+        PROPERTY_STRING(emissionTable, "the name of the file tabulating properties for polarized emission by "
+                                       "arbitrarily aligned spheroidal grains")
+        ATTRIBUTE_RELEVANT_IF(emissionTable, "tableTypeOneTable")
+
         PROPERTY_STRING(
             alignedEmissionTable,
             "the name of the file tabulating properties for polarized emission by perfectly aligned spheroidal grains")
-        ATTRIBUTE_DEFAULT_VALUE(alignedEmissionTable, "")
-        ATTRIBUTE_REQUIRED_IF(alignedEmissionTable, "false")
+        ATTRIBUTE_RELEVANT_IF(alignedEmissionTable, "tableTypeTwoTables")
 
         PROPERTY_STRING(
             nonAlignedEmissionTable,
             "the name of the file tabulating properties for polarized emission by non-aligned spheroidal grains")
-        ATTRIBUTE_DEFAULT_VALUE(nonAlignedEmissionTable, "")
-        ATTRIBUTE_REQUIRED_IF(nonAlignedEmissionTable, "false")
+        ATTRIBUTE_RELEVANT_IF(nonAlignedEmissionTable, "tableTypeTwoTables")
 
         PROPERTY_DOUBLE(alignmentFraction,
                         "the alignment fraction of the spheroidal grains with the local magnetic field")
         ATTRIBUTE_DEFAULT_VALUE(alignmentFraction, "1.")
         ATTRIBUTE_MIN_VALUE(alignmentFraction, "0.")
         ATTRIBUTE_MAX_VALUE(alignmentFraction, "1.")
+        ATTRIBUTE_RELEVANT_IF(alignmentFraction, "tableTypeBuiltin|tableTypeTwoTables")
 
     ITEM_END()
 
 public:
-    /** This function verifies that all attribute values have been appropriately set. */
-    void setupSelfBefore() override;
-
     /** This function returns a brief human-readable identifier for this grain composition. */
     string name() const override;
 

--- a/SKIRT/core/SpheroidalSilicateGrainComposition.hpp
+++ b/SKIRT/core/SpheroidalSilicateGrainComposition.hpp
@@ -27,12 +27,30 @@ class SpheroidalSilicateGrainComposition : public PolarizedSilicateGrainComposit
                   "a spheroidal silicate dust grain composition with support for polarization")
         ATTRIBUTE_TYPE_DISPLAYED_IF(SpheroidalSilicateGrainComposition, "Spheroidal")
 
-        PROPERTY_STRING(spheroidalEmissionTable,
-                        "the name of the file tabulating properties for polarized emission by spheroidal grains")
+        PROPERTY_STRING(
+            alignedEmissionTable,
+            "the name of the file tabulating properties for polarized emission by perfectly aligned spheroidal grains")
+        ATTRIBUTE_DEFAULT_VALUE(alignedEmissionTable, "")
+        ATTRIBUTE_REQUIRED_IF(alignedEmissionTable, "false")
+
+        PROPERTY_STRING(
+            nonAlignedEmissionTable,
+            "the name of the file tabulating properties for polarized emission by non-aligned spheroidal grains")
+        ATTRIBUTE_DEFAULT_VALUE(nonAlignedEmissionTable, "")
+        ATTRIBUTE_REQUIRED_IF(nonAlignedEmissionTable, "false")
+
+        PROPERTY_DOUBLE(alignmentFraction,
+                        "the alignment fraction of the spheroidal grains with the local magnetic field")
+        ATTRIBUTE_DEFAULT_VALUE(alignmentFraction, "1.")
+        ATTRIBUTE_MIN_VALUE(alignmentFraction, "0.")
+        ATTRIBUTE_MAX_VALUE(alignmentFraction, "1.")
 
     ITEM_END()
 
 public:
+    /** This function verifies that all attribute values have been appropriately set. */
+    void setupSelfBefore() override;
+
     /** This function returns a brief human-readable identifier for this grain composition. */
     string name() const override;
 

--- a/SKIRT/core/SpheroidalSilicateGrainComposition.hpp
+++ b/SKIRT/core/SpheroidalSilicateGrainComposition.hpp
@@ -17,10 +17,26 @@
 
     The optical scattering and absorption properties and the calorimetric properties are taken from
     the PolarizedSilicateGrainComposition class, from which this class derives. The optical
-    properties driving the polarization signature for therrmal emission are obtained from
+    properties driving the polarization signature for thermal emission are obtained from
     additional built-in tables or can be provided by the user, as described below.
 
-    TO DO: describe built-in and file input options. */
+    In the current implementation, the internally used optical properties table always assumes a
+    fixed spheroidal dust model with a constant alignment. The table generally is a linear
+    combination of a table for non-aligned grains and one for aligned grains, combined using a
+    linear alignment fraction between 0 and 1. The builtin version of the tables further assumes
+    that only grains with sizes larger than 0.1 micron align with the magnetic field, and that the
+    spheroidal grains have shapes distributed according to a CDE2 shape distribution (this is the
+    fudicial model presented in Vandenbroucke, Baes & Camps, 2020).
+    
+    If this fiducial model is not sufficient, users can provide their own custom tables, e.g.
+    generated using CosTuuM. There are two options: either the user computes the tables for a
+    specific alignment fraction and provides a single table, or the user provides separate tables
+    for perfectly aligned and non-aligned grains. In the latter case, SKIRT will use the alignment
+    fraction to appropriately interpolate between the two tables, as in the builtin case.
+    
+    The choice between the 3 different scenarios (builtin tables with interpolation, a single
+    custom table without interpolation or two custom tables with interpolation) is configured
+    through an enum. */
 class SpheroidalSilicateGrainComposition : public PolarizedSilicateGrainComposition
 {
 


### PR DESCRIPTION
**Description**
This pull request adds configuration options to `SpheroidalSilicateGrainComposition` and `SpheroidalGraphiteGrainComposition` that allow the use of builtin pre-computed tables with optical properties as well as custom user-provided tables. It also adds appropriate documentation to the classes.

**Motivation**
So far, all spheroidal grain properties had to be provided by the user and alignment had to be computed manually. The use of builtin tables and the availability of a new `alignmentFraction` parameter provide SKIRT with powerful builtin capabilities to deal with spheroidal grains without the need for specific user input.

**Tests**
The configuration options have been tested manually by running various configurations through SKIRT and checking that SKIRT reacts appropriately. The internal calculation of the interpolated table has been tested by comparing a SKIRT-interpolated run with a manually interpolated run for an alignment fraction of 0.75.

**Guidelines**
The code was automatically formatted and adheres to the coding standard.

**Context**
This pull request requires an upgrade of the SKIRT resource pack.